### PR TITLE
Update README.md to include missing backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Experimental configuration (subject to change):
       ;; return truthy to check the inclusing of the component's query in an ancestor
       {:query-inclusion-filter (fn [component-instance comp-class] 
                                  (not= comp-class :com.example.ui/MyComponent))})
-``
+```
 ### Valid idents
 
 Warn when there is something fishy about the component's ident:


### PR DESCRIPTION
Added missing backtick below "experimental configuration"